### PR TITLE
Ruby 3.1.0 compat

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos]
-        ruby-version: ['2.6', '2.7', head]
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', head]
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/crabstone/binding.rb
+++ b/lib/crabstone/binding.rb
@@ -7,12 +7,15 @@ module Crabstone
   module Binding
     class Instruction < FFI::ManagedStruct
       def self.release(obj)
+        return if @freed
+
         ptr = case obj
               when FFI::Pointer
                 obj
               else
                 obj.pointer
               end
+        @freed = true
         detail_ptr = ptr.+(Instruction.offset_of(:detail)).read_pointer
         Binding.free(detail_ptr)
         Binding.free(ptr)

--- a/lib/crabstone/binding.rb
+++ b/lib/crabstone/binding.rb
@@ -7,7 +7,12 @@ module Crabstone
   module Binding
     class Instruction < FFI::ManagedStruct
       def self.release(obj)
-        ptr = obj.pointer
+        ptr = case obj
+              when FFI::Pointer
+                obj
+              else
+                obj.pointer
+              end
         detail_ptr = ptr.+(Instruction.offset_of(:detail)).read_pointer
         Binding.free(detail_ptr)
         Binding.free(ptr)


### PR DESCRIPTION
We get a warning in Ruby 3.1.0. I think the exception was possibly always there, but is only exposed by default in Ruby 3.0.

```
/Users/chrisseaton/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/simplecov-0.17.1/lib/simplecov/source_file.rb:94: warning: Exception in finalizer #<FFI::AutoPointer::CallableReleaser:0x0000000104ba8a60 @ptr=#<FFI::Pointer address=0x0000600003c5b660>, @proc=#<Method: Crabstone::Binding::Instruction.release(obj) /Users/chrisseaton/Documents/crabstone/lib/crabstone/binding.rb:9>, @autorelease=true>
/Users/chrisseaton/Documents/crabstone/lib/crabstone/binding.rb:10:in `release': undefined method `pointer' for #<FFI::Pointer address=0x0000600003c5b660> (NoMethodError)

        ptr = obj.pointer
                 ^^^^^^^^
	from /Users/chrisseaton/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/ffi-1.15.4/lib/ffi/autopointer.rb:175:in `call'
	from /Users/chrisseaton/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/ffi-1.15.4/lib/ffi/autopointer.rb:175:in `release'
	from /Users/chrisseaton/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/ffi-1.15.4/lib/ffi/autopointer.rb:150:in `call'
```