### PR TITLE
Fix undefined instance variable warning

### DIFF
--- a/lib/crabstone/binding.rb
+++ b/lib/crabstone/binding.rb
@@ -7,15 +7,10 @@ module Crabstone
   module Binding
     class Instruction < FFI::ManagedStruct
       def self.release(obj)
-        return if @freed
+        return if defined?(@freed)
 
-        ptr = case obj
-              when FFI::Pointer
-                obj
-              else
-                obj.pointer
-              end
         @freed = true
+        ptr = obj.is_a?(FFI::Pointer) ? obj : obj.pointer
         detail_ptr = ptr.+(Instruction.offset_of(:detail)).read_pointer
         Binding.free(detail_ptr)
         Binding.free(ptr)

--- a/lib/crabstone/binding.rb
+++ b/lib/crabstone/binding.rb
@@ -7,13 +7,9 @@ module Crabstone
   module Binding
     class Instruction < FFI::ManagedStruct
       def self.release(obj)
-        return if defined?(@freed)
-
-        @freed = true
-        ptr = obj.is_a?(FFI::Pointer) ? obj : obj.pointer
-        detail_ptr = ptr.+(Instruction.offset_of(:detail)).read_pointer
+        detail_ptr = obj.+(Instruction.offset_of(:detail)).read_pointer
         Binding.free(detail_ptr)
-        Binding.free(ptr)
+        Binding.free(obj)
       end
     end
 

--- a/spec/instruction_spec.rb
+++ b/spec/instruction_spec.rb
@@ -64,7 +64,8 @@ describe Crabstone::Instruction do
   end
 
   it 'release' do
-    inst = @cs.disasm("\xc3", 0).first
-    Crabstone::Binding::Instruction.release(inst.raw_insn)
+    pointer = @cs.disasm("\xc3", 0).first.raw_insn.pointer
+    pointer.autorelease = false
+    Crabstone::Binding::Instruction.release(pointer)
   end
 end


### PR DESCRIPTION
Also tweak the case-when statement to a single line to increase code coverage.

Signed-off-by: david942j <david942j@gmail.com>