### PR TITLE
Fix disasm segfault when skipdata_cb raises errors

### DIFF
--- a/lib/crabstone/disassembler.rb
+++ b/lib/crabstone/disassembler.rb
@@ -81,9 +81,8 @@ module Crabstone
           code = code.read_array_of_uchar(sz).pack('c*')
           begin
             Integer(yield(code, offset))
-          rescue StandardError
-            warn "Error in skipdata callback: #{$ERROR_INFO}"
-            # It will go on to crash, but now at least there's more info :)
+          rescue StandardError => e
+            raise Crabstone::ErrSkipData, "Error in skipdata callback: #{e.message}"
           end
         end
       end

--- a/spec/disassembler_spec.rb
+++ b/spec/disassembler_spec.rb
@@ -56,9 +56,7 @@ describe Crabstone::Disassembler do
     expect(cs.disasm("\x90\xFFP", 0).map { |i| i.mnemonic.to_s }).to eq %w[nop]
 
     cs.skipdata { raise 'ggsmida' }
-    expect { cs.disasm("\xff", 0) }
-      .to output("Error in skipdata callback: ggsmida\n").to_stderr
-                                                         .and raise_error(Crabstone::ErrOK)
+    expect { cs.disasm("\xff", 0) }.to raise_error(Crabstone::ErrSkipData)
   end
 
   it 'disasm error' do


### PR DESCRIPTION
Close #23

Tested
```
  for i in {0..10000}
  do
    echo "i=$i"
    bundle exec rake spec || break
  done
```
passed with fix.