### PR TITLE
Rake generate without Python binding installed

### DIFF
--- a/tasks/generate/all.rake
+++ b/tasks/generate/all.rake
@@ -4,7 +4,7 @@ import 'tasks/generate/arch.rake'
 import 'tasks/generate/binding.rake'
 
 namespace :generate do
-  desc 'Invoke generate:arch and generate:binding'
+  desc 'Invoke generate:arch and generate:binding. Example: rake "generate:all[$HOME/capstone-5.0.1, 5]"'
   task :all, :path_to_capstone, :version do |_t, args|
     Rake::Task['generate:arch'].invoke(args.path_to_capstone, args.version)
     Rake::Task['generate:binding'].invoke(args.path_to_capstone, args.version)

--- a/tasks/generate/arch.rb
+++ b/tasks/generate/arch.rb
@@ -34,7 +34,7 @@ module Generate
         py_mod = File.basename(file).sub('.py', '')
         arch = py_mod == 'systemz' ? 'sysz' : py_mod
         mod = module_name(arch)
-        content = insert_methods(arch, Python.new(py_mod).to_layout.join("\n"))
+        content = insert_methods(arch, Python.new(cs_path('bindings/python/capstone'), py_mod).to_layout.join("\n"))
         write_file("#{arch}.rb", <<~REQUIRE, mod, content)
           require 'ffi'
 

--- a/tasks/generate/generator.rb
+++ b/tasks/generate/generator.rb
@@ -26,8 +26,12 @@ module Generate
 
     private
 
+    def cs_path(sub = '')
+      File.join(@cs_path, sub)
+    end
+
     def glob(pattern, &block)
-      Dir.glob(File.join(@cs_path, pattern), &block)
+      Dir.glob(cs_path(pattern), &block)
     end
 
     def write_file(filename, rqr, mod, res)

--- a/tasks/generate/print_structs.py
+++ b/tasks/generate/print_structs.py
@@ -1,14 +1,21 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
-import sys
-import os
 import importlib
+import os
+import sys
 
 def str_type(tp):
     if hasattr(tp, '_length_'):
         return '{}, {}'.format(tp._type_.__name__, tp._length_)
     else:
         return tp.__name__
+
+def load_capstone_binding(path):
+    spec = importlib.util.spec_from_file_location('capstone', f'{path}/__init__.py')
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules['capstone'] = mod
+    spec.loader.exec_module(mod)
+
 def display(klass):
     # If any of the fields is not a native type, call display recursively.
     for var, tp in klass._fields_:
@@ -25,12 +32,13 @@ def display(klass):
     print('')
 
 def work(arch):
-    mod = importlib.import_module('capstone.' + arch)
-    main_struct = filter(lambda x: x.startswith('Cs'), dir(mod))[0]
+    mod = getattr(sys.modules['capstone'], arch)
+    main_struct = next(filter(lambda x: x.startswith('Cs'), dir(mod)))
     display(getattr(mod, main_struct))
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print('Usage: {} x86'.format(sys.argv[0]))
+    if len(sys.argv) != 3:
+        print('Usage: {} <path/to/capstone/bindings/python/capstone> x86'.format(sys.argv[0]))
         os.exit(1)
-    work(sys.argv[1])
+    load_capstone_binding(sys.argv[1])
+    work(sys.argv[2])

--- a/tasks/generate/python.rb
+++ b/tasks/generate/python.rb
@@ -9,7 +9,8 @@ module Generate
   class Python
     attr_reader :arch
 
-    def initialize(file)
+    def initialize(path_to_cs_py_binding, file)
+      @path_to_py = path_to_cs_py_binding
       @file = file
       @arch = Helper.module_name(@file).downcase
     end
@@ -17,7 +18,7 @@ module Generate
     # Use an extra python script to read those structs out and print them in normalized form to have the parsing
     # procedure much easier.
     def to_layout
-      res = `#{File.join(__dir__, 'print_structs.py')} #{@file}`
+      res = `#{File.join(__dir__, 'print_structs.py')} '#{@path_to_py}' '#{@file}'`
       raise 'Unexpected error in python script' unless $CHILD_STATUS.exitstatus.zero?
 
       first = true


### PR DESCRIPTION
Previous binding structures generation requires the desired Capstone Python binding installed as the default capstone package. This commit makes it support fetching Python structures from the Capstone source, hence it gets rid of the requirement of Python capstone package being installed.

Also a minor change on print_structs.py to support Python3.