### PR TITLE
Rake tasks fixup

### DIFF
--- a/tasks/generate/all.rake
+++ b/tasks/generate/all.rake
@@ -9,6 +9,6 @@ namespace :generate do
     Rake::Task['generate:arch'].invoke(args.path_to_capstone, args.version)
     Rake::Task['generate:binding'].invoke(args.path_to_capstone, args.version)
 
-    Rake::Task['rubocop:auto_correct'].invoke
+    Rake::Task['rubocop:autocorrect'].invoke
   end
 end

--- a/tasks/generate/arch.rb
+++ b/tasks/generate/arch.rb
@@ -15,6 +15,7 @@ module Generate
         arch = File.basename(file).sub('_const.py', '')
         res = File.foreach(file).map do |line|
           next '' if line.strip.start_with?('#')
+          next '' if line.start_with?('from')
 
           line.strip.empty? ? "\n" : line.gsub("#{arch.upcase}_", '')
         end.join

--- a/tasks/generate/binding.rb
+++ b/tasks/generate/binding.rb
@@ -53,8 +53,8 @@ module Generate
 
     def parser
       HParser.new do |config|
-        config.include_path << File.join(@cs_path, 'include')
-        config.file = File.join(@cs_path, 'include', @version.major >= 4 ? 'capstone' : '', 'capstone.h')
+        config.include_path << cs_path('include')
+        config.file = cs_path('include', @version.major >= 4 ? 'capstone' : '', 'capstone.h')
       end
     end
   end

--- a/tasks/generate/generator.rb
+++ b/tasks/generate/generator.rb
@@ -26,8 +26,8 @@ module Generate
 
     private
 
-    def cs_path(sub = '')
-      File.join(@cs_path, sub)
+    def cs_path(*paths)
+      File.join(@cs_path, *paths)
     end
 
     def glob(pattern, &block)

--- a/tasks/generate/hparser.rb
+++ b/tasks/generate/hparser.rb
@@ -92,9 +92,12 @@ module Generate
 
     class Field
       class << self
+        # parse('unsigned int *field [10];')
+        #   => Field.new(['field', 10], :uint32, 1)
         def parse(str)
           tokens = str.split
           var = tokens.pop
+          var = tokens.pop + var while var.start_with?('[')
           tokens << var.slice!(0..var.rindex('*')) if var.start_with?('*')
           var = parse_var(var)
           type, ref_c, type_s = parse_type(tokens.join(' '))
@@ -124,6 +127,7 @@ module Generate
           when /^uint(8|16|32|64)_t$/ then str[0..-3].to_sym
           when 'unsigned int' then :uint32
           when 'char' then str.to_sym
+          when '_Bool' then :bool
           end
         end
       end


### PR DESCRIPTION
1. replace 'auto_correct' with 'autocorrect'
2. ignore import lines when parsing Python files
3. utilize Generator#cs_path when possible
4. improve header parser to
   - consider spaces between array field and its size
   - consider the boolean type